### PR TITLE
Added -I switch to disable the IBM TrackPoint in Lenovo ThinkPads.

### DIFF
--- a/tools/syndaemon.c
+++ b/tools/syndaemon.c
@@ -136,16 +136,16 @@ toggle_touchpad(Bool enable)
     if (pad_disabled && enable) {
         data = previous_state;
         pad_disabled = False;
-	if (verbose)
+        if (verbose)
             printf("Enable\n");
-	
-	if ( disable_trackpoint && trackpoint ) {
-	  if (verbose) {
-	    printf("TrackPoint enabled\n");
-	  }
-	  trackpoint_state = Enabled;
-	  tp_data = trackpoint_state;
-	}	
+
+        if ( disable_trackpoint && trackpoint ) {
+          if (verbose) {
+            printf("TrackPoint enabled\n");
+          }
+          trackpoint_state = Enabled;
+          tp_data = trackpoint_state;
+        }
     }
     else if (!pad_disabled && !enable &&
              previous_state != disable_state && previous_state != TouchpadOff) {
@@ -154,14 +154,14 @@ toggle_touchpad(Bool enable)
         data = disable_state;
         if (verbose)
             printf("Disable\n");
-	
-	if ( disable_trackpoint && trackpoint ) {
-	  if (verbose) {
-	    printf("TrackPoint disabled\n");
-	  }
-	  trackpoint_state = Disabled;
-	  tp_data = trackpoint_state;
-	}
+
+        if ( disable_trackpoint && trackpoint ) {
+          if (verbose) {
+            printf("TrackPoint disabled\n");
+          }
+          trackpoint_state = Disabled;
+          tp_data = trackpoint_state;
+        }
     }
     else
         return;
@@ -586,7 +586,7 @@ dp_get_device(Display * dpy)
     }
 
     /* Disable the TPPS/2 IBM TrackPoint also */
-    
+
     if (disable_trackpoint ) {
       char trackpoint_name[] = "TPPS/2 IBM TrackPoint";
       info = XListInputDevices(dpy, &ndevices);
@@ -680,9 +680,9 @@ main(int argc, char *argv[])
         case 'v':
             verbose = 1;
             break;
-	case 'I':
-	    disable_trackpoint = 1;
-	    break;
+        case 'I':
+            disable_trackpoint = 1;
+            break;
         case '?':
         default:
             usage();


### PR DESCRIPTION
I recently got a Lenovo ThinkPad X230. I soon noticed that the cursor was making random jumps while typing. I activated syndaemon, but it didn't help. I then noticed that the cause for the jumps was that my fingers touched the TrackPad buttons, that weren't disabled since the TrackPad is another pointing device and listed as a mouse. This is not actually a touchpad problem but seems to affect many synaptics users with ThinkPads. Also, disabling the mouse buttons below the spacebar when disabling the touchpad seems intuitive so I've made addition to syndaemon code. 

I added switch -I to disable TrackPoint while typing. It disables only mouses with name "TPPS/2 IBM TrackPoint" so it doesn't affect other mouses or touchpad. All my additions should be run only when switch -I is present so the original functioning of the program is stored when not using the switch.